### PR TITLE
Add React frontend scaffold

### DIFF
--- a/ecotrack-frontend/package.json
+++ b/ecotrack-frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ecotrack-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/main.tsx",
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.5.3",
+    "@tanstack/react-query": "^5.75.1",
+    "chart.js": "^4.4.9",
+    "react-chartjs-2": "^5.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "ts-loader": "^9.5.1",
+    "webpack": "^5.91.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/ecotrack-frontend/public/index.html
+++ b/ecotrack-frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EcoTrack Frontend</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="/bundle.js"></script>
+</body>
+</html>

--- a/ecotrack-frontend/src/App.tsx
+++ b/ecotrack-frontend/src/App.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Routes, Route, Link, Navigate } from 'react-router-dom';
+import Dashboard from './pages/Dashboard';
+import Orders from './pages/Orders';
+import Profile from './pages/Profile';
+
+export default function App() {
+  return (
+    <div>
+      <nav style={{ padding: '1rem', background: '#f2f2f2' }}>
+        <Link to="/dashboard">Dashboard</Link> |{' '}
+        <Link to="/orders">Orders</Link> |{' '}
+        <Link to="/profile">Profile</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/orders" element={<Orders />} />
+        <Route path="/profile" element={<Profile />} />
+      </Routes>
+    </div>
+  );
+}

--- a/ecotrack-frontend/src/components/OrderStatus.tsx
+++ b/ecotrack-frontend/src/components/OrderStatus.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const statusColors: Record<string, string> = {
+  pending: '#ff9800',
+  processing: '#2196f3',
+  completed: '#4caf50',
+  cancelled: '#f44336'
+};
+
+export default function OrderStatus({ status }: { status: string }) {
+  const color = statusColors[status] || '#757575';
+  return <span style={{ color }}>{status}</span>;
+}

--- a/ecotrack-frontend/src/main.tsx
+++ b/ecotrack-frontend/src/main.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+
+const queryClient = new QueryClient();
+
+const root = document.getElementById('root');
+if (root) {
+  ReactDOM.createRoot(root).render(
+    <React.StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </React.StrictMode>
+  );
+}

--- a/ecotrack-frontend/src/pages/Dashboard.tsx
+++ b/ecotrack-frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Chart as ChartJS, ArcElement, CategoryScale, LinearScale, BarElement } from 'chart.js';
+import { Doughnut, Bar } from 'react-chartjs-2';
+
+ChartJS.register(ArcElement, CategoryScale, LinearScale, BarElement);
+
+interface Analytics {
+  totalOrders: number;
+  totalEarnings: number;
+  totalEnvironmentalImpact: number;
+  recycledByMaterial: Record<string, number>;
+  ordersByStatus: Record<string, number>;
+  monthlyEarnings: number[];
+  yearlyVolume: Record<string, number>;
+}
+
+export default function Dashboard() {
+  const { data, isLoading } = useQuery<Analytics>(['analytics'], async () => {
+    const res = await fetch('/api/analytics');
+    if (!res.ok) throw new Error('Failed to load analytics');
+    return res.json();
+  });
+
+  if (isLoading || !data) return <p>Loading...</p>;
+
+  const doughnutData = {
+    labels: Object.keys(data.recycledByMaterial),
+    datasets: [{
+      data: Object.values(data.recycledByMaterial),
+      backgroundColor: ['#4caf50', '#2196f3', '#ff9800', '#e91e63']
+    }]
+  };
+
+  const barData = {
+    labels: Array.from({ length: 12 }, (_, i) => i + 1),
+    datasets: [{
+      label: 'Earnings',
+      data: data.monthlyEarnings,
+      backgroundColor: '#2196f3'
+    }]
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Dashboard</h2>
+      <p>Total orders: {data.totalOrders}</p>
+      <p>Total earnings: {data.totalEarnings.toFixed(2)}</p>
+      <p>Total environmental impact: {data.totalEnvironmentalImpact.toFixed(2)}</p>
+
+      <div style={{ maxWidth: 300 }}>
+        <Doughnut data={doughnutData} />
+      </div>
+      <div style={{ maxWidth: 400 }}>
+        <Bar data={barData} />
+      </div>
+    </div>
+  );
+}

--- a/ecotrack-frontend/src/pages/Orders.tsx
+++ b/ecotrack-frontend/src/pages/Orders.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import OrderStatus from '../components/OrderStatus';
+
+interface Order {
+  id: string;
+  materialType: string;
+  volume: number;
+  pickupAddress: string;
+  status: string;
+  createdAt: string;
+}
+
+export default function Orders() {
+  const { data, isLoading } = useQuery<Order[]>(['orders'], async () => {
+    const res = await fetch('/api/orders');
+    if (!res.ok) throw new Error('Failed to load orders');
+    return res.json();
+  });
+
+  if (isLoading || !data) return <p>Loading...</p>;
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Your Orders</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Material</th>
+            <th>Volume</th>
+            <th>Status</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map(o => (
+            <tr key={o.id}>
+              <td>{o.id}</td>
+              <td>{o.materialType}</td>
+              <td>{o.volume} kg</td>
+              <td><OrderStatus status={o.status} /></td>
+              <td>{new Date(o.createdAt).toLocaleDateString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ecotrack-frontend/src/pages/Profile.tsx
+++ b/ecotrack-frontend/src/pages/Profile.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  companyName?: string;
+}
+
+export default function Profile() {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery<User>(['profile'], async () => {
+    const res = await fetch('/api/profile');
+    if (!res.ok) throw new Error('Failed to load profile');
+    return res.json();
+  });
+
+  const mutation = useMutation(async (updated: Partial<User>) => {
+    const res = await fetch('/api/profile', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updated)
+    });
+    if (!res.ok) throw new Error('Failed to update profile');
+    return res.json();
+  }, {
+    onSuccess: () => queryClient.invalidateQueries(['profile'])
+  });
+
+  const [name, setName] = useState('');
+  const [company, setCompany] = useState('');
+
+  if (isLoading || !data) return <p>Loading...</p>;
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Profile</h2>
+      <p>Email: {data.email}</p>
+      <label>
+        Name:
+        <input value={name} onChange={e => setName(e.target.value)} placeholder={data.name} />
+      </label>
+      <label>
+        Company:
+        <input value={company} onChange={e => setCompany(e.target.value)} placeholder={data.companyName || ''} />
+      </label>
+      <button onClick={() => mutation.mutate({ name, companyName: company })}>Save</button>
+    </div>
+  );
+}

--- a/ecotrack-frontend/tsconfig.json
+++ b/ecotrack-frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/ecotrack-frontend/webpack.config.js
+++ b/ecotrack-frontend/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+module.exports = {
+  entry: './src/main.tsx',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: '/',
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  devServer: {
+    static: path.join(__dirname, 'public'),
+    historyApiFallback: true,
+    port: 3000,
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- replace old `ecotrack-frontend` submodule with React project
- bootstrap React app with routing
- add pages for dashboard, orders, and profile
- implement basic order status component
- add webpack configuration for dev server

## Testing
- `npm test` *(fails: jest not found)*
- `(cd ecotrack && npm test)` *(fails: jest: Permission denied)*
